### PR TITLE
Ignore sqlite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 *.db
 *.db.*
+jutut-db
 
 /local_settings.py
 /local_templates/


### PR DESCRIPTION
# Description

The default configuration suggested in `local_settings.py` creates a sqlite file called `jutut-db` under the main directory, added said file into `.gitignore`.