### PR TITLE
Improve UX when submitting feedback

### DIFF
--- a/feedback/locale/fi/LC_MESSAGES/django.po
+++ b/feedback/locale/fi/LC_MESSAGES/django.po
@@ -843,6 +843,10 @@ msgid "This feedback has unsaved changes!"
 msgstr "Palautteessa on tallentamattomia muutoksia!"
 
 #: feedback/templates_j2/feedback/_form.html
+msgid "Feedback received."
+msgstr "Palaute vastaanotettu."
+
+#: feedback/templates_j2/feedback/_form.html
 msgid "Submit"
 msgstr "Lähetä"
 

--- a/feedback/templates_j2/feedback/_form.html
+++ b/feedback/templates_j2/feedback/_form.html
@@ -164,17 +164,19 @@
 			{{ _("This feedback has unsaved changes!") }}
 		</div>
 
-		<div>
-			<div class="btn-toolbar gap-2">
-				<input
-					type="submit"
-					value="{{ _('Submit') }}"
-					class="btn btn-primary aplus-submit mr-2">
-				<input
-					type="reset"
-					value="{{ _('Reset changes') }}"
-					class="btn btn-danger only-when-edited">
-			</div>
+		<div id="feedback-received-message" class="alert alert-info" style="display: none">
+			{{ _("Feedback received.") }}
+		</div>
+
+		<div class="btn-toolbar gap-2">
+			<input
+				type="submit"
+				value="{{ _('Submit') }}"
+				class="btn btn-primary aplus-submit mr-2">
+			<input
+				type="reset"
+				value="{{ _('Reset changes') }}"
+				class="btn btn-danger only-when-edited">
 		</div>
 	</form>
 
@@ -182,6 +184,12 @@
 	<script>
 		(function($) {
 			const f = $('#{{ form_id }}');
+			// implement feedback received notification
+			// needs to be only shown when feedback has just been sent by student
+			const feedbackJustReceived = f.closest('.exercise-response').data('aplus-grader-feedback-just-received');
+			if (feedbackJustReceived) {
+				$('#feedback-received-message').show();
+			}
 			// implement show more
 			const c = f.find('.history-well'), m = c.find('.show-more');
 			m.click(function() { c.find('li.initially-hidden').removeClass('initially-hidden').show(); m.hide(); });

--- a/feedback/templates_j2/feedback/_form.html
+++ b/feedback/templates_j2/feedback/_form.html
@@ -194,7 +194,9 @@
 			const c = f.find('.history-well'), m = c.find('.show-more');
 			m.click(function() { c.find('li.initially-hidden').removeClass('initially-hidden').show(); m.hide(); });
 			// empty textfields
-			c.next('textarea, input[type="text"]').val("");
+			window.setTimeout(function() {
+				c.next('textarea, input[type="text"]').val("");
+			})
 			// implement edited notification
 			const o = f.find('.only-when-edited'), i = f.serialize();
 			let s = false;


### PR DESCRIPTION
Show a "feedback received" alert and hide the Submit button after submission to signal students that their feedback has been received and they can move on.

**Why?**

Student submission UX has been unclear, resulting in semi-accidental double submissions. See #122 for details. This should prevent these double submissions. Requires related A+ code to work (https://github.com/apluslms/a-plus/pull/1505), so that jutut knows the exercise on A+ side has just received the "grading" result.

Fixes #122 

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.


**Did you test the changes in**

- [ ] Chrome
- [X] Firefox
- [ ] This pull request cannot be tested in the browser.